### PR TITLE
Fix invalid message <number>

### DIFF
--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -129,7 +129,7 @@ export const sendMessage = (dispatch: Dispatch<HistoryAction>, text: string, fro
     let postback;
     try {
         postback = JSON.parse(text);
-        text = postback.text;
+        text = postback.text || text;
         delete postback.text;
     } catch(e) {
         // Error occurs


### PR DESCRIPTION
#### What does this PR do?
- There was an issue when the user types a numeric messages, as `1234` …
- it seems that `JSON.parse` function resolves a valid json and was ignoring the json format...

#### Where should the reviewer start?
:checkered_flag: 

#### How should this be manually tested?
1. Send a message with a valid number `!isNaN()`

#### Any background context you want to provide?
http://stackoverflow.com/questions/17224536/why-is-one-number-valid-json
#### What are the relevant tickets?
Closes #x

#### Screenshots (if appropriate)
:camera:

#### Questions
:question:

